### PR TITLE
fix broken test after creating with a custom package

### DIFF
--- a/src/main/resources/archetype-resources/src/main/resources/jsexample/component-connector.js
+++ b/src/main/resources/archetype-resources/src/main/resources/jsexample/component-connector.js
@@ -1,4 +1,4 @@
-#set($weirdPackage = $groupId.replaceAll("[.]", "_"))
+#set($weirdPackage = $package.replaceAll("[.]", "_"))
 window.${weirdPackage}_jsexample_MyJavaScriptComponent = function() {
     // Create basic input element
     var el = document.createElement("input");


### PR DESCRIPTION
Fix (hopefully / untested) the broken test if you create a project with a custom package. 

For example: if you create a groupId with com.vaadin.addons and later define the package as "awesomeaddon". The final package with your classes is below com.vaadin.addons.awesomeaddon. This won't get recognized here only with the groupId and so the browsertest fails because it can't find the correct js methods.